### PR TITLE
Fixes Ruby version manager detection for Linux

### DIFF
--- a/lib/multi_ruby_runner/version_manager.rb
+++ b/lib/multi_ruby_runner/version_manager.rb
@@ -7,9 +7,9 @@ class MultiRubyRunner
     def self.detect
       which_ruby = `which ruby`
       case which_ruby
-      when /\/\.*rbenv\//
+      when /\/\.?rbenv\//
         Rbenv.new(which_ruby)
-      when /\/\.*rvm\//
+      when /\/\.?rvm\//
         Rvm.new(which_ruby)
       else
         None.new(which_ruby)

--- a/lib/multi_ruby_runner/version_manager.rb
+++ b/lib/multi_ruby_runner/version_manager.rb
@@ -7,9 +7,9 @@ class MultiRubyRunner
     def self.detect
       which_ruby = `which ruby`
       case which_ruby
-      when /\/\.rbenv\//
+      when /\/\.*rbenv\//
         Rbenv.new(which_ruby)
-      when /\/\.rvm\//
+      when /\/\.*rvm\//
         Rvm.new(which_ruby)
       else
         None.new(which_ruby)


### PR DESCRIPTION
This PR resolves a bug with the Ruby version manager detection algorithm on Linux.

The detection algorithm previously assumed that a period was present in the version manager file path, e.g. `/usr/local/.rbenv/shims/ruby`. I confirmed that this functions perfectly on OS X machines.

However, this period does not exist in the file path when operating on a Linux machine. The file path on Linux looks something like `/usr/local/rbenv/shims/ruby`.

### Changes
- Modified the version manager detection algorithm so that it properly considers the period (or lack thereof) when parsing the Ruby version manager file path.